### PR TITLE
fixes readme steps

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,10 @@ A django-dashing_ widget pack
 Quick start
 -----------
 
+#. Install the latest stable version from PyPi:
+
+    $ pip install widget_party
+
 #. Add "widget_party" to your INSTALLED_APPS setting like this::
 
     INSTALLED_APPS = (


### PR DESCRIPTION
Adds the missing step indicating that the package should be installed from pypi

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mverteuil/widget-party/4)
<!-- Reviewable:end -->
